### PR TITLE
Update docker image name to match with change in repo

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,7 +26,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: fedcampus/dyn_flower_android_drf
+          images: fedcampus/fedkit-backend
           flavor: |
             latest=true
           tags: |

--- a/backend/README.md
+++ b/backend/README.md
@@ -70,7 +70,7 @@ This project can be deployed using Docker, which ensures that it will run the sa
 The Docker image for this project is hosted and actively updated on Docker Hub via the CI/CD pipeline. To pull the image to your local machine, run the following command:
 
 ```sh
-docker pull fedcampus/dyn_flower_android_drf:latest
+docker pull fedcampus/fedkit-backend:latest
 ```
 
 ### Prepare the model
@@ -88,7 +88,7 @@ docker run --name name-of-your-choice \
 -p 8000:8000 \
 -p 8080:8080 \
 -v /path/to/static:/app/static \
-fedcampus/dyn_flower_android_drf:latest
+fedcampus/fedkit-backend:latest
 ```
 
 This command maps port 8000 (the value on the right) inside the Docker container to port 8000 (the value on the left) on your host machine, and does the same for port 8080.


### PR DESCRIPTION
This PR updates the image name to fedkit-backend as well as updating the documentation