### PR TITLE
Split Android library and separate out training

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,6 +31,7 @@ android {
     }
 
     dataBinding {
+        //noinspection DataBindingWithoutKapt
         enabled = true
     }
 
@@ -45,6 +46,7 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.core:core-ktx:1.10.1'
@@ -52,9 +54,8 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:runner:1.5.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    implementation project(path: ':fed_kit')
 
     // Local dependencies.
-
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation project(path: ':fed_kit')
+    implementation project(path: ':fed_kit_train')
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
 
     defaultConfig {
         applicationId "org.eu.fedcampus.android_client"
@@ -21,15 +21,13 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    buildFeatures {
+        viewBinding true
+    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-
-    viewBinding {
-        enabled = true
-    }
-
     dataBinding {
         //noinspection DataBindingWithoutKapt
         enabled = true

--- a/android/app/src/main/java/org/eu/fedcampus/android_client/MainActivity.kt
+++ b/android/app/src/main/java/org/eu/fedcampus/android_client/MainActivity.kt
@@ -14,6 +14,7 @@ import org.eu.fedcampus.fed_kit.examples.cifar10.Float3DArray
 import org.eu.fedcampus.fed_kit.examples.cifar10.loadData
 import org.eu.fedcampus.fed_kit.examples.cifar10.sampleSpec
 import org.eu.fedcampus.fed_kit_train.FlowerClient
+import org.eu.fedcampus.fed_kit_train.helpers.deviceId
 import org.eu.fedcampus.fed_kit_train.helpers.loadMappedFile
 import java.util.Date
 import java.util.Locale
@@ -110,7 +111,7 @@ class MainActivity : AppCompatActivity() {
     suspend fun connectInBackground(participationId: Int, backendUrl: Uri, host: Uri) {
         Log.i(TAG, "Backend URL: $backendUrl")
         train = Train(this, backendUrl.toString(), sampleSpec())
-        train.enableTelemetry(org.eu.fedcampus.fed_kit_train.helpers.deviceId(this))
+        train.enableTelemetry(deviceId(this))
         val modelFile = train.prepareModel(DATA_TYPE)
         val serverData = train.getServerInfo(binding.startFreshCheckBox.isChecked)
         if (serverData.port == null) {

--- a/android/app/src/main/java/org/eu/fedcampus/android_client/MainActivity.kt
+++ b/android/app/src/main/java/org/eu/fedcampus/android_client/MainActivity.kt
@@ -8,14 +8,13 @@ import androidx.appcompat.app.AppCompatActivity
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import org.eu.fedcampus.android_client.databinding.ActivityMainBinding
-import org.eu.fedcampus.fed_kit.FlowerClient
 import org.eu.fedcampus.fed_kit.Train
 import org.eu.fedcampus.fed_kit.examples.cifar10.DATA_TYPE
 import org.eu.fedcampus.fed_kit.examples.cifar10.Float3DArray
 import org.eu.fedcampus.fed_kit.examples.cifar10.loadData
 import org.eu.fedcampus.fed_kit.examples.cifar10.sampleSpec
-import org.eu.fedcampus.fed_kit.helpers.deviceId
-import org.eu.fedcampus.fed_kit.helpers.loadMappedFile
+import org.eu.fedcampus.fed_kit_train.FlowerClient
+import org.eu.fedcampus.fed_kit_train.helpers.loadMappedFile
 import java.util.Date
 import java.util.Locale
 
@@ -111,7 +110,7 @@ class MainActivity : AppCompatActivity() {
     suspend fun connectInBackground(participationId: Int, backendUrl: Uri, host: Uri) {
         Log.i(TAG, "Backend URL: $backendUrl")
         train = Train(this, backendUrl.toString(), sampleSpec())
-        train.enableTelemetry(deviceId(this))
+        train.enableTelemetry(org.eu.fedcampus.fed_kit_train.helpers.deviceId(this))
         val modelFile = train.prepareModel(DATA_TYPE)
         val serverData = train.getServerInfo(binding.startFreshCheckBox.isChecked)
         if (serverData.port == null) {

--- a/android/benchmark/build.gradle
+++ b/android/benchmark/build.gradle
@@ -44,7 +44,8 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    implementation project(path: ':fed_kit')
 
     // Local dependencies.
+    implementation project(path: ':fed_kit')
+    implementation project(path: ':fed_kit_train')
 }

--- a/android/benchmark/src/main/java/org/eu/fedcampus/benchmark/BenchmarkActivity.kt
+++ b/android/benchmark/src/main/java/org/eu/fedcampus/benchmark/BenchmarkActivity.kt
@@ -16,7 +16,7 @@ import org.eu.fedcampus.fed_kit.background.BaseTrainWorker
 import org.eu.fedcampus.fed_kit.background.fastTrainWorkRequest
 import org.eu.fedcampus.fed_kit.background.trainWorkerData
 import org.eu.fedcampus.fed_kit.examples.cifar10.Float3DArray
-import org.eu.fedcampus.fed_kit.helpers.deviceId
+import org.eu.fedcampus.fed_kit_train.helpers.deviceId
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -50,9 +50,7 @@ class BenchmarkActivity : AppCompatActivity() {
         val trainWork =
             fastTrainWorkRequest<BenchmarkCifar10Worker, Float3DArray, FloatArray>(inputData)
         workManager.enqueueUniquePeriodicWork(
-            BaseTrainWorker.TAG,
-            ExistingPeriodicWorkPolicy.REPLACE,
-            trainWork
+            BaseTrainWorker.TAG, ExistingPeriodicWorkPolicy.UPDATE, trainWork
         )
         appendLog("Submit training work request for $uri")
     }

--- a/android/fed_kit/build.gradle
+++ b/android/fed_kit/build.gradle
@@ -70,12 +70,6 @@ dependencies {
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation 'com.google.protobuf:protoc:3.23.4'
 
-    // TensorFlow Lite.
-    implementation 'org.tensorflow:tensorflow-lite:2.13.0'
-    implementation 'org.tensorflow:tensorflow-lite-gpu:2.13.0'
-    implementation 'org.tensorflow:tensorflow-lite-support:0.4.4'
-    implementation 'org.tensorflow:tensorflow-lite-select-tf-ops:2.13.0'
-
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/android/fed_kit/build.gradle
+++ b/android/fed_kit/build.gradle
@@ -79,4 +79,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+
+    // Local dependencies
+    implementation project(path: ':fed_kit_train')
 }

--- a/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/FlowerServiceRunnable.kt
+++ b/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/FlowerServiceRunnable.kt
@@ -17,8 +17,9 @@ import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
-import org.eu.fedcampus.fed_kit.db.TFLiteModel
-import org.eu.fedcampus.fed_kit.helpers.assertIntsEqual
+import org.eu.fedcampus.fed_kit_train.db.TFLiteModel
+import org.eu.fedcampus.fed_kit_train.helpers.assertIntsEqual
+import org.eu.fedcampus.fed_kit_train.FlowerClient
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 

--- a/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/HttpClient.kt
+++ b/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/HttpClient.kt
@@ -1,7 +1,7 @@
 package org.eu.fedcampus.fed_kit
 
 import okhttp3.ResponseBody
-import org.eu.fedcampus.fed_kit.db.TFLiteModel
+import org.eu.fedcampus.fed_kit_train.db.TFLiteModel
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.create

--- a/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/Train.kt
+++ b/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/Train.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.util.Log
 import io.grpc.ManagedChannel
 import kotlinx.coroutines.*
-import org.eu.fedcampus.fed_kit.db.TFLiteModel
+import org.eu.fedcampus.fed_kit_train.db.TFLiteModel
+import org.eu.fedcampus.fed_kit_train.FlowerClient
+import org.eu.fedcampus.fed_kit_train.SampleSpec
 import retrofit2.http.*
 import java.io.File
 import java.nio.MappedByteBuffer

--- a/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/TrainState.kt
+++ b/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/TrainState.kt
@@ -1,7 +1,8 @@
 package org.eu.fedcampus.fed_kit
 
 import io.grpc.ManagedChannel
-import org.eu.fedcampus.fed_kit.db.TFLiteModel
+import org.eu.fedcampus.fed_kit_train.db.TFLiteModel
+import org.eu.fedcampus.fed_kit_train.FlowerClient
 
 sealed class TrainState<X : Any, Y : Any> {
     class Initialized<X : Any, Y : Any> : TrainState<X, Y>()

--- a/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/background/BaseTrainWorker.kt
+++ b/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/background/BaseTrainWorker.kt
@@ -16,10 +16,10 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkerParameters
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.eu.fedcampus.fed_kit.FlowerClient
-import org.eu.fedcampus.fed_kit.SampleSpec
+import org.eu.fedcampus.fed_kit_train.FlowerClient
+import org.eu.fedcampus.fed_kit_train.SampleSpec
 import org.eu.fedcampus.fed_kit.Train
-import org.eu.fedcampus.fed_kit.helpers.loadMappedFile
+import org.eu.fedcampus.fed_kit_train.helpers.loadMappedFile
 import java.util.concurrent.TimeUnit
 
 /**

--- a/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/examples/cifar10/cifar10.kt
+++ b/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/examples/cifar10/cifar10.kt
@@ -1,8 +1,8 @@
 package org.eu.fedcampus.fed_kit.examples.cifar10
 
-import org.eu.fedcampus.fed_kit.SampleSpec
-import org.eu.fedcampus.fed_kit.helpers.classifierAccuracy
-import org.eu.fedcampus.fed_kit.helpers.negativeLogLikelihoodLoss
+import org.eu.fedcampus.fed_kit_train.SampleSpec
+import org.eu.fedcampus.fed_kit_train.helpers.classifierAccuracy
+import org.eu.fedcampus.fed_kit_train.helpers.negativeLogLikelihoodLoss
 
 fun sampleSpec() = SampleSpec<Float3DArray, FloatArray>(
     { it.toTypedArray() },

--- a/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/examples/cifar10/loadData.kt
+++ b/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/examples/cifar10/loadData.kt
@@ -7,7 +7,7 @@ import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.eu.fedcampus.fed_kit.FlowerClient
+import org.eu.fedcampus.fed_kit_train.FlowerClient
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.util.concurrent.ExecutionException

--- a/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/examples/fedmcrnn/fedmcrnn.kt
+++ b/android/fed_kit/src/main/java/org/eu/fedcampus/fed_kit/examples/fedmcrnn/fedmcrnn.kt
@@ -1,8 +1,8 @@
 package org.eu.fedcampus.fed_kit.examples.fedmcrnn
 
-import org.eu.fedcampus.fed_kit.SampleSpec
-import org.eu.fedcampus.fed_kit.helpers.maxSquaredErrorLoss
-import org.eu.fedcampus.fed_kit.helpers.placeholderAccuracy
+import org.eu.fedcampus.fed_kit_train.SampleSpec
+import org.eu.fedcampus.fed_kit_train.helpers.maxSquaredErrorLoss
+import org.eu.fedcampus.fed_kit_train.helpers.placeholderAccuracy
 
 fun sampleSpec() = SampleSpec<Float2DArray, FloatArray>(
     { it.toTypedArray() },

--- a/android/fed_kit_train/build.gradle.kts
+++ b/android/fed_kit_train/build.gradle.kts
@@ -24,4 +24,10 @@ android {
 dependencies {
     implementation("androidx.core:core-ktx:1.10.1")
     testImplementation("junit:junit:4.13.2")
+
+    // TensorFlow Lite.
+    implementation ("org.tensorflow:tensorflow-lite:2.13.0")
+    implementation ("org.tensorflow:tensorflow-lite-gpu:2.13.0")
+    implementation ("org.tensorflow:tensorflow-lite-support:0.4.4")
+    implementation ("org.tensorflow:tensorflow-lite-select-tf-ops:2.13.0")
 }

--- a/android/fed_kit_train/build.gradle.kts
+++ b/android/fed_kit_train/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "org.eu.fedcampus.fed_kit_train"
+    compileSdk = 33
+
+    defaultConfig {
+        minSdk = 24
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.10.1")
+    testImplementation("junit:junit:4.13.2")
+}

--- a/android/fed_kit_train/src/main/AndroidManifest.xml
+++ b/android/fed_kit_train/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest>
+
+</manifest>

--- a/android/fed_kit_train/src/main/java/org/eu/fedcampus/fed_kit_train/FlowerClient.kt
+++ b/android/fed_kit_train/src/main/java/org/eu/fedcampus/fed_kit_train/FlowerClient.kt
@@ -1,8 +1,8 @@
-package org.eu.fedcampus.fed_kit
+package org.eu.fedcampus.fed_kit_train
 
 import android.util.Log
-import org.eu.fedcampus.fed_kit.db.TFLiteModel
-import org.eu.fedcampus.fed_kit.helpers.assertIntsEqual
+import org.eu.fedcampus.fed_kit_train.db.TFLiteModel
+import org.eu.fedcampus.fed_kit_train.helpers.assertIntsEqual
 import org.tensorflow.lite.Interpreter
 import java.lang.Integer.min
 import java.nio.ByteBuffer

--- a/android/fed_kit_train/src/main/java/org/eu/fedcampus/fed_kit_train/SampleSpec.kt
+++ b/android/fed_kit_train/src/main/java/org/eu/fedcampus/fed_kit_train/SampleSpec.kt
@@ -1,10 +1,11 @@
-package org.eu.fedcampus.fed_kit
+package org.eu.fedcampus.fed_kit_train
 
 /**
  * Specification of the samples for [FlowerClient].
  * [convertX] and [convertY] are needed only because of the limitation of generics,
  * so simply fill in `{ it.toTypedArray() }`.
- * Feel free to choose the loss and accuracy functions from [org.eu.fedcampus.fed_kit.helpers].
+ * Feel free to choose the loss and accuracy functions from
+ * [org.eu.fedcampus.fed_kit_train.helpers].
  * @param emptyY Create an array of empty [Y].
  * @param loss Given test samples and logits, calculate test loss.
  * @param accuracy Given test samples and logits, calculate test accuracy.

--- a/android/fed_kit_train/src/main/java/org/eu/fedcampus/fed_kit_train/db/TFLiteModel.kt
+++ b/android/fed_kit_train/src/main/java/org/eu/fedcampus/fed_kit_train/db/TFLiteModel.kt
@@ -1,4 +1,4 @@
-package org.eu.fedcampus.fed_kit.db
+package org.eu.fedcampus.fed_kit_train.db
 
 import android.content.Context
 import java.io.File

--- a/android/fed_kit_train/src/main/java/org/eu/fedcampus/fed_kit_train/helpers/accuracy.kt
+++ b/android/fed_kit_train/src/main/java/org/eu/fedcampus/fed_kit_train/helpers/accuracy.kt
@@ -1,6 +1,6 @@
-package org.eu.fedcampus.fed_kit.helpers
+package org.eu.fedcampus.fed_kit_train.helpers
 
-import org.eu.fedcampus.fed_kit.Sample
+import org.eu.fedcampus.fed_kit_train.Sample
 
 /** Zero-one accuracy for one-hot classifier. */
 fun <X> classifierAccuracy(

--- a/android/fed_kit_train/src/main/java/org/eu/fedcampus/fed_kit_train/helpers/helpers.kt
+++ b/android/fed_kit_train/src/main/java/org/eu/fedcampus/fed_kit_train/helpers/helpers.kt
@@ -1,4 +1,4 @@
-package org.eu.fedcampus.fed_kit.helpers
+package org.eu.fedcampus.fed_kit_train.helpers
 
 import android.annotation.SuppressLint
 import android.content.Context

--- a/android/fed_kit_train/src/main/java/org/eu/fedcampus/fed_kit_train/helpers/loss.kt
+++ b/android/fed_kit_train/src/main/java/org/eu/fedcampus/fed_kit_train/helpers/loss.kt
@@ -1,6 +1,6 @@
-package org.eu.fedcampus.fed_kit.helpers
+package org.eu.fedcampus.fed_kit_train.helpers
 
-import org.eu.fedcampus.fed_kit.Sample
+import org.eu.fedcampus.fed_kit_train.Sample
 import kotlin.math.ln
 
 fun <X> negativeLogLikelihoodLoss(

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,3 +1,4 @@
 include ':app'
 include ':fed_kit'
 include ':benchmark'
+include ':fed_kit_train'

--- a/fed_kit_client/android/app/build.gradle
+++ b/fed_kit_client/android/app/build.gradle
@@ -27,7 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     namespace "org.eu.fedcampus.fed_kit_client"
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdk flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/fed_kit_client/android/app/build.gradle
+++ b/fed_kit_client/android/app/build.gradle
@@ -71,4 +71,5 @@ dependencies {
 
     // Local dependencies.
     implementation project(':fed_kit')
+    implementation project(':fed_kit_train')
 }

--- a/fed_kit_client/android/app/src/main/kotlin/org/eu/fedcampus/fed_kit_client/MainActivity.kt
+++ b/fed_kit_client/android/app/src/main/kotlin/org/eu/fedcampus/fed_kit_client/MainActivity.kt
@@ -27,9 +27,9 @@ class MainActivity : FlutterActivity() {
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
-        val messager = flutterEngine.dartExecutor.binaryMessenger
-        MethodChannel(messager, "fed_kit_flutter").setMethodCallHandler(::handle)
-        EventChannel(messager, "fed_kit_flutter_events").setStreamHandler(object :
+        val messenger = flutterEngine.dartExecutor.binaryMessenger
+        MethodChannel(messenger, "fed_kit_flutter").setMethodCallHandler(::handle)
+        EventChannel(messenger, "fed_kit_flutter_events").setStreamHandler(object :
             EventChannel.StreamHandler {
             override fun onListen(arguments: Any?, eventSink: EventSink?) {
                 if (eventSink === null) {

--- a/fed_kit_client/android/app/src/main/kotlin/org/eu/fedcampus/fed_kit_client/MainActivity.kt
+++ b/fed_kit_client/android/app/src/main/kotlin/org/eu/fedcampus/fed_kit_client/MainActivity.kt
@@ -10,14 +10,14 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.Result
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
-import org.eu.fedcampus.fed_kit.FlowerClient
 import org.eu.fedcampus.fed_kit.Train
 import org.eu.fedcampus.fed_kit.examples.cifar10.DATA_TYPE
 import org.eu.fedcampus.fed_kit.examples.cifar10.Float3DArray
 import org.eu.fedcampus.fed_kit.examples.cifar10.loadData
 import org.eu.fedcampus.fed_kit.examples.cifar10.sampleSpec
-import org.eu.fedcampus.fed_kit.helpers.deviceId
-import org.eu.fedcampus.fed_kit.helpers.loadMappedFile
+import org.eu.fedcampus.fed_kit_train.FlowerClient
+import org.eu.fedcampus.fed_kit_train.helpers.deviceId
+import org.eu.fedcampus.fed_kit_train.helpers.loadMappedFile
 
 class MainActivity : FlutterActivity() {
     val scope = MainScope()

--- a/fed_kit_client/android/settings.gradle
+++ b/fed_kit_client/android/settings.gradle
@@ -12,3 +12,5 @@ apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gra
 
 include ':fed_kit'
 project(':fed_kit').projectDir = new File('../../android/fed_kit/')
+include ':fed_kit_train'
+project(':fed_kit_train').projectDir = new File('../../android/fed_kit_train/')


### PR DESCRIPTION
All other repositories currently using FedKit Android will need to add `fed_kit_train` to both `settings.gradle` and `build.gradle` to keep working.

- [x] Adapt to this change in `FedCampus_APP`.
- [x] Adapt to this change in `FedCampus_Flutter`.

This change is to prepare for the transition to use native platforms only for training and use Dart to handle communication to both the backend and Flower servers.
